### PR TITLE
silence cp

### DIFF
--- a/croissant.sh
+++ b/croissant.sh
@@ -118,8 +118,8 @@ if [ "$choice" = false ]; then
     chromium_root_dir="/home/chronos/RAW"
     flag_linux=false
     mkdir -p /home/chronos/RAW/usr/lib64
-    cp -av /home/chronos/local/{lib,boot} /home/chronos/RAW/
-    cp -av /home/chronos/local/usr/lib64/{dri,va} /home/chronos/RAW/usr/lib64/
+    cp -a /home/chronos/local/{lib,boot} /home/chronos/RAW/
+    cp -a /home/chronos/local/usr/lib64/{dri,va} /home/chronos/RAW/usr/lib64/
     if [ ! $? -eq 0 ]; then echo "Error while copying ChromiumOS files locally (insufficent disk space?)"; abort_chromefy; fi
 fi
 umount /home/chronos/local 2>/dev/null
@@ -179,14 +179,14 @@ else
 fi
 
 #Copies all ChromeOS system files
-cp -av /home/chronos/image/* /home/chronos/local
+cp -a /home/chronos/image/* /home/chronos/local
 umount /home/chronos/image
 
 #Copies modules and certificates from ChromiumOS
 rm -rf /home/chronos/local/lib/firmware
 rm -rf /home/chronos/local/lib/modules/ 
-cp -av "$chromium_root_dir"/{lib,boot} /home/chronos/local/
-cp -nav "$chromium_root_dir"/usr/lib64/{dri,va} /home/chronos/local/usr/lib64/ #Extra GPU drivers
+cp -a "$chromium_root_dir"/{lib,boot} /home/chronos/local/
+cp -na "$chromium_root_dir"/usr/lib64/{dri,va} /home/chronos/local/usr/lib64/ #Extra GPU drivers
 rm -rf /home/chronos/local/etc/modprobe.d/alsa*.conf
 
 echo "Is your wireless card bcm43xx? Answer no if unsure (y/n)"
@@ -248,16 +248,16 @@ if [ "$flag_tpm1" = true ]; then
 	rm -rf /home/chronos/local/etc/init/{attestationd,cr50-metrics,cr50-result,cr50-update,tpm_managerd,trunksd,u2fd}.conf
 
 	#Copy TPM 1.2 file from tpm1image
-	cp -av /home/chronos/tpm1image/etc/init/{chapsd,cryptohomed,cryptohomed-client,tcsd,tpm-probe}.conf /home/chronos/local/etc/init/
-	cp -av /home/chronos/tpm1image/etc/tcsd.conf /home/chronos/local/etc/
-	cp -av /home/chronos/tpm1image/usr/bin/{tpmc,chaps_client} /home/chronos/local/usr/bin/
-	cp -av /home/chronos/tpm1image/usr/lib64/libtspi.so{,.1{,.2.0}} /home/chronos/local/usr/lib64/
-	cp -av /home/chronos/tpm1image/usr/sbin/{chapsd,cryptohome,cryptohomed,cryptohome-path,tcsd} /home/chronos/local/usr/sbin/
-	cp -av /home/chronos/tpm1image/usr/share/cros/init/{tcsd-pre-start,chapsd}.sh /home/chronos/local/usr/share/cros/init/
-    cp -av /home/chronos/tpm1image/etc/dbus-1/system.d/{Cryptohome,org.chromium.Chaps}.conf /home/chronos/local/etc/dbus-1/system.d/
+	cp -a /home/chronos/tpm1image/etc/init/{chapsd,cryptohomed,cryptohomed-client,tcsd,tpm-probe}.conf /home/chronos/local/etc/init/
+	cp -a /home/chronos/tpm1image/etc/tcsd.conf /home/chronos/local/etc/
+	cp -a /home/chronos/tpm1image/usr/bin/{tpmc,chaps_client} /home/chronos/local/usr/bin/
+	cp -a /home/chronos/tpm1image/usr/lib64/libtspi.so{,.1{,.2.0}} /home/chronos/local/usr/lib64/
+	cp -a /home/chronos/tpm1image/usr/sbin/{chapsd,cryptohome,cryptohomed,cryptohome-path,tcsd} /home/chronos/local/usr/sbin/
+	cp -a /home/chronos/tpm1image/usr/share/cros/init/{tcsd-pre-start,chapsd}.sh /home/chronos/local/usr/share/cros/init/
+    cp -a /home/chronos/tpm1image/etc/dbus-1/system.d/{Cryptohome,org.chromium.Chaps}.conf /home/chronos/local/etc/dbus-1/system.d/
     if [ ! -f /home/chronos/local/usr/lib64/libecryptfs.so ] && [ -f /home/chronos/tpm1image/usr/lib64/libecryptfs.so ]; then
-        cp -av /home/chronos/tpm1image/usr/lib64/libecryptfs* /home/chronos/local/usr/lib64/
-        cp -av /home/chronos/tpm1image/usr/lib64/ecryptfs /home/chronos/local/usr/lib64/
+        cp -a /home/chronos/tpm1image/usr/lib64/libecryptfs* /home/chronos/local/usr/lib64/
+        cp -a /home/chronos/tpm1image/usr/lib64/ecryptfs /home/chronos/local/usr/lib64/
     fi
 
 	#Add tss user and group
@@ -269,8 +269,8 @@ fi
 
 #Fix for TPM2 images (must pass third parameter) (TPM emulation method)
 if [ "$flag_vtpm" = true ]; then
-    cp -av /home/chronos/RAW/swtpm/usr/sbin/* /home/chronos/local/usr/sbin
-    cp -av /home/chronos/RAW/swtpm/usr/lib64/* /home/chronos/local/usr/lib64
+    cp -a /home/chronos/RAW/swtpm/usr/sbin/* /home/chronos/local/usr/sbin
+    cp -a /home/chronos/RAW/swtpm/usr/lib64/* /home/chronos/local/usr/lib64
     
     cd /home/chronos/local/usr/lib64
     ln -s libswtpm_libtpms.so.0.0.0 libswtpm_libtpms.so.0


### PR DESCRIPTION
Currently, the croissant script runs cp with -v on every invocation, causing every single file on the Chrome OS root to be printed.
This is an issue because the script is so verbose that even with a huge scrollback everything in a terminal will be pushed away, including the first lines of output of the script.
In addition, it's pointless anyway as cp will still display errors in silent mode.